### PR TITLE
MADS handling

### DIFF
--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -395,7 +395,7 @@ class CarState(CarStateBase, MadsCarState):
       ret.batteryDetails.power        = main_cp.vl["MEB_HVEM_01"]["Engine_Power"] # engine power output
       ret.batteryDetails.temperature  = main_cp.vl["DCDC_03"]["DC_Temperatur"] # dcdc converter temperature
       
-    MadsCarState.update_mads(self, ret, pt_cp)
+    MadsCarState.update_mads(self, ret, ret_sp, pt_cp)
 
     self.frame += 1
     return ret, ret_sp

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -6,12 +6,15 @@ from opendbc.car.volkswagen.values import DBC, CanBus, NetworkLocation, Transmis
                                                       CarControllerParams, VolkswagenFlags
 from opendbc.car.volkswagen.speed_limit_manager import SpeedLimitManager
 
+from opendbc.sunnypilot.car.volkswagen.mads import MadsCarState
+
 ButtonType = structs.CarState.ButtonEvent.Type
 
 
-class CarState(CarStateBase):
+class CarState(CarStateBase, MadsCarState):
   def __init__(self, CP, CP_SP):
     super().__init__(CP, CP_SP)
+    MadsCarState.__init__(self, CP, CP_SP)
     self.frame = 0
     self.eps_init_complete = False
     self.CCP = CarControllerParams(CP)
@@ -391,6 +394,8 @@ class CarState(CarStateBase):
       ret.batteryDetails.soc          = ret.batteryDetails.charge / ret.batteryDetails.capacity * 100 if ret.batteryDetails.capacity > 0 else 0 # battery SoC in percent
       ret.batteryDetails.power        = main_cp.vl["MEB_HVEM_01"]["Engine_Power"] # engine power output
       ret.batteryDetails.temperature  = main_cp.vl["DCDC_03"]["DC_Temperatur"] # dcdc converter temperature
+      
+    MadsCarState.update_mads(self, ret, can_parsers)
 
     self.frame += 1
     return ret, ret_sp

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -395,7 +395,7 @@ class CarState(CarStateBase, MadsCarState):
       ret.batteryDetails.power        = main_cp.vl["MEB_HVEM_01"]["Engine_Power"] # engine power output
       ret.batteryDetails.temperature  = main_cp.vl["DCDC_03"]["DC_Temperatur"] # dcdc converter temperature
       
-    MadsCarState.update_mads(self, ret, ret_sp, pt_cp)
+    MadsCarState.update_mads(self, ret, pt_cp)
 
     self.frame += 1
     return ret, ret_sp

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -395,7 +395,7 @@ class CarState(CarStateBase, MadsCarState):
       ret.batteryDetails.power        = main_cp.vl["MEB_HVEM_01"]["Engine_Power"] # engine power output
       ret.batteryDetails.temperature  = main_cp.vl["DCDC_03"]["DC_Temperatur"] # dcdc converter temperature
       
-    MadsCarState.update_mads(self, ret, pt_cp)
+    MadsCarState.update_mads(self, ret, pt_cp, hca_status)
 
     self.frame += 1
     return ret, ret_sp

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -395,7 +395,7 @@ class CarState(CarStateBase, MadsCarState):
       ret.batteryDetails.power        = main_cp.vl["MEB_HVEM_01"]["Engine_Power"] # engine power output
       ret.batteryDetails.temperature  = main_cp.vl["DCDC_03"]["DC_Temperatur"] # dcdc converter temperature
       
-    MadsCarState.update_mads(self, ret, can_parsers)
+    MadsCarState.update_mads(self, ret, pt_cp)
 
     self.frame += 1
     return ret, ret_sp

--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -134,12 +134,18 @@ class CarControllerParams:
         Button(structs.CarState.ButtonEvent.Type.decelCruise, "GRA_ACC_01", "GRA_Tip_Runter", [1]),
         Button(structs.CarState.ButtonEvent.Type.gapAdjustCruise, "GRA_ACC_01", "GRA_Verstellung_Zeitluecke", [3]),
       ]
+      
+      # !!! this is sunnypilot MADS only !!!
+      MADS_BUTTON = [
+        Button(structs.CarState.ButtonEvent.Type.lkas, "", "", [0]),
+      ]
+      # !!! this is sunnypilot MADS only !!!
 
-      self.BUTTONS = BASE_BUTTONS + [
+      self.BUTTONS = BASE_BUTTONS + MADS_BUTTON + [
         Button(structs.CarState.ButtonEvent.Type.cancel, "GRA_ACC_01", "GRA_Hauptschalter", [1]), # main button cancels ACC operation when ACC active
       ]
 
-      self.BUTTONS_ALT = BASE_BUTTONS + [
+      self.BUTTONS_ALT = BASE_BUTTONS + MADS_BUTTON + [
         Button(structs.CarState.ButtonEvent.Type.cancel, "GRA_ACC_01", "GRA_Abbrechen", [1]), # there is a physical cancel button
       ]
 

--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -134,18 +134,12 @@ class CarControllerParams:
         Button(structs.CarState.ButtonEvent.Type.decelCruise, "GRA_ACC_01", "GRA_Tip_Runter", [1]),
         Button(structs.CarState.ButtonEvent.Type.gapAdjustCruise, "GRA_ACC_01", "GRA_Verstellung_Zeitluecke", [3]),
       ]
-      
-      # !!! this is sunnypilot MADS only !!!
-      MADS_BUTTON = [
-        Button(structs.CarState.ButtonEvent.Type.lkas, "", "", [0]),
-      ]
-      # !!! this is sunnypilot MADS only !!!
 
-      self.BUTTONS = BASE_BUTTONS + MADS_BUTTON + [
+      self.BUTTONS = BASE_BUTTONS + [
         Button(structs.CarState.ButtonEvent.Type.cancel, "GRA_ACC_01", "GRA_Hauptschalter", [1]), # main button cancels ACC operation when ACC active
       ]
 
-      self.BUTTONS_ALT = BASE_BUTTONS + MADS_BUTTON + [
+      self.BUTTONS_ALT = BASE_BUTTONS + [
         Button(structs.CarState.ButtonEvent.Type.cancel, "GRA_ACC_01", "GRA_Abbrechen", [1]), # there is a physical cancel button
       ]
 

--- a/opendbc/sunnypilot/car/volkswagen/mads.py
+++ b/opendbc/sunnypilot/car/volkswagen/mads.py
@@ -1,0 +1,36 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+from collections import namedtuple
+
+from opendbc.car import structs
+from opendbc.car.interfaces import CarStateBase
+
+MAX_STEERING_ANGLE = 90.0
+
+MadsDataSP = namedtuple("MadsDataSP",
+                        ["lka_icon_states", "lat_active"])
+
+
+class MadsCarController:
+  def __init__(self):
+    self.mads = MadsDataSP(False, False)
+
+    self.lka_icon_states = False
+    self.lat_active = False
+
+  def mads_status_update(self, CC: structs.CarControl, CC_SP: structs.CarControlSP, CS: CarStateBase) -> MadsDataSP:
+    if CC_SP.mads.available:
+      self.lka_icon_states = self.lat_active
+      self.lat_active = CC.latActive and abs(CS.out.steeringAngleDeg) < MAX_STEERING_ANGLE
+    else:
+      self.lka_icon_states = CC.enabled
+      self.lat_active = CC.latActive
+
+    return MadsDataSP(self.lka_icon_states, self.lat_active)
+
+  def update(self, CC: structs.CarControl, CC_SP: structs.CarControlSP, CS: CarStateBase) -> None:
+    self.mads = self.mads_status_update(CC, CC_SP, CS)

--- a/opendbc/sunnypilot/car/volkswagen/mads.py
+++ b/opendbc/sunnypilot/car/volkswagen/mads.py
@@ -19,13 +19,12 @@ ButtonType = structs.CarState.ButtonEvent.Type
 class MadsCarState(MadsCarStateBase):
   def __init__(self, CP: structs.CarParams, CP_SP: structs.CarParamsSP):
     super().__init__(CP, CP_SP)
-    self.prev_cruise_fault = False
 
   def update_mads(self, ret: structs.CarState, can_parser_pt: CANParser) -> None:
     self.prev_lkas_button = self.lkas_button
 
-    # block mads from detecting a cruise state transition at standstill while cruise is temporary not available
-    if can_parser_pt.vl["Motor_51"]["TSK_Status"] == 6 and ret.standstill:
+    # block mads from detecting a cruise state transition in park or not in drive mode while cruise is temporary not available
+    if can_parser_pt.vl["Motor_51"]["TSK_Status"] == 6 and (ret.gearShifter != GearShifter.drive or ret.parkingBrake):
       ret.cruiseState.available = True
     
     # some newer gen MEB cars do not have a main cruise button and a native cancel button is present   

--- a/opendbc/sunnypilot/car/volkswagen/mads.py
+++ b/opendbc/sunnypilot/car/volkswagen/mads.py
@@ -11,7 +11,6 @@ from opendbc.car import Bus,structs
 
 from opendbc.sunnypilot.mads_base import MadsCarStateBase
 from opendbc.can.parser import CANParser
-from opendbc.car.volkswagen.values import GearShifter
 
 ButtonType = structs.CarState.ButtonEvent.Type
 
@@ -23,8 +22,8 @@ class MadsCarState(MadsCarStateBase):
   def update_mads(self, ret: structs.CarState, can_parser_pt: CANParser) -> None:
     self.prev_lkas_button = self.lkas_button
 
-    # block mads from detecting a cruise state transition in park or not in drive mode while cruise is temporary not available
-    if can_parser_pt.vl["Motor_51"]["TSK_Status"] == 6 and (ret.gearShifter != GearShifter.drive or ret.parkingBrake):
+    # block mads from detecting a cruise state transition in parked mode while cruise is temporary not available
+    if can_parser_pt.vl["Motor_51"]["TSK_Status"] == 6 and ret.parkingBrake:
       ret.cruiseState.available = True
     
     # some newer gen MEB cars do not have a main cruise button and a native cancel button is present   

--- a/opendbc/sunnypilot/car/volkswagen/mads.py
+++ b/opendbc/sunnypilot/car/volkswagen/mads.py
@@ -32,7 +32,7 @@ class MadsCarState(MadsCarStateBase):
       
     # some newer gen MEB cars do not have a main cruise button and a native cancel button is present      
     for b in ret.buttonEvents:
-      if b.type == ButtonType.cancel and not b.pressed: # on rising edge
+      if b.type == ButtonType.cancel and b.pressed: # on rising edge
         user_disable = True
       elif b.type in (ButtonType.setCruise, ButtonType.resumeCruise) and not b.pressed: # on falling edge
         user_enable = True

--- a/opendbc/sunnypilot/car/volkswagen/mads.py
+++ b/opendbc/sunnypilot/car/volkswagen/mads.py
@@ -19,7 +19,7 @@ class MadsCarState(MadsCarStateBase):
   def __init__(self, CP: structs.CarParams, CP_SP: structs.CarParamsSP):
     super().__init__(CP, CP_SP)
 
-  def update_mads(self, ret: structs.CarState, can_parsers: dict[StrEnum, CANParser]) -> None:
+  def update_mads(self, ret: structs.CarState, can_parser_pt: CANParser) -> None:
     self.prev_lkas_button = self.lkas_button
     user_enable = False
     user_disable = False
@@ -27,7 +27,7 @@ class MadsCarState(MadsCarStateBase):
     cp = can_parsers[Bus.pt]
     
     # block temp fault when parked to prevent mads self activation when car removes the temp fault by switching into a drive mode
-    if pt_cp.vl["Motor_51"]["TSK_Status"] == 6 and ret.parkingBrake:
+    if can_parser_pt.vl["Motor_51"]["TSK_Status"] == 6 and ret.parkingBrake:
       ret.cruiseState.available = True
       
     # some newer gen MEB cars do not have a main cruise button and a native cancel button is present      
@@ -37,7 +37,7 @@ class MadsCarState(MadsCarStateBase):
       elif b.type in (ButtonType.setCruise, ButtonType.resumeCruise) and not b.pressed: # on falling edge
         user_enable = True
     
-    steering_enabled = pt_cp.vl["QFK_01"]["LatCon_HCA_Status"] == "ACTIVE" # presume mads is actively steering
+    steering_enabled = can_parser_pt.vl["QFK_01"]["LatCon_HCA_Status"] == "ACTIVE" # presume mads is actively steering
     
     lat_cancel_action = steering_enabled and user_disable
     lat_enable_action = not steering_enabled and user_enable

--- a/opendbc/sunnypilot/car/volkswagen/mads.py
+++ b/opendbc/sunnypilot/car/volkswagen/mads.py
@@ -48,5 +48,7 @@ class MadsCarState(MadsCarStateBase):
         break
     
     steering_enabled = hca_status == "ACTIVE" # assume mads is actively steering
+    cruise_standby   = not ret.cruiseState.enabled
     
-    self.lkas_button = steering_enabled and user_disable
+    # disable MADS if user cancels while cruise not enabled
+    self.lkas_button = steering_enabled and user_disable and cruise_standby

--- a/opendbc/sunnypilot/car/volkswagen/mads.py
+++ b/opendbc/sunnypilot/car/volkswagen/mads.py
@@ -43,8 +43,7 @@ class MadsCarState(MadsCarStateBase):
     self.prev_lkas_button = self.lkas_button
     
     # get cancel button press
-    user_disable = any(b.type == ButtonType.accelCruise and b.pressed for b in ret.buttonEvents) # for testing
-    #user_disable = any(b.type == ButtonType.cancel and b.pressed for b in ret.buttonEvents)
+    user_disable = any(b.type == ButtonType.cancel and b.pressed for b in ret.buttonEvents)
     
     # get states
     steering_enabled = hca_status == "ACTIVE" # assume mads is actively steering

--- a/opendbc/sunnypilot/car/volkswagen/mads.py
+++ b/opendbc/sunnypilot/car/volkswagen/mads.py
@@ -23,10 +23,13 @@ class MadsCarState(MadsCarStateBase):
     self.prev_lkas_button = self.lkas_button
 
     # block mads from detecting a cruise state transition in parked mode while cruise is temporary not available
-    if can_parser_pt.vl["Motor_51"]["TSK_Status"] == 6 and ret.parkingBrake:
+    parking_brake_not_fully_open = can_parser_pt.vl["ESC_50"]["EPB_Status"] in (1, 3, 4)
+    temp_cruise_fault = can_parser_pt.vl["Motor_51"]["TSK_Status"] == 6
+    if temp_cruise_fault and parking_brake_not_fully_open:
       ret.cruiseState.available = True
     
-    # some newer gen MEB cars do not have a main cruise button and a native cancel button is present   
+    # some newer gen MEB cars do not have a main cruise button and a native cancel button is present
+    # cruise state can not be fully toggled off for these cars!    
     user_disable = False
          
     for b in ret.buttonEvents:

--- a/opendbc/sunnypilot/car/volkswagen/mads.py
+++ b/opendbc/sunnypilot/car/volkswagen/mads.py
@@ -5,31 +5,41 @@ This file is part of sunnypilot and is licensed under the MIT License.
 See the LICENSE.md file in the root directory for more details.
 """
 
-from enum import StrEnum
-
-from opendbc.car import Bus,structs
+from opendbc.car import structs
 
 from opendbc.sunnypilot.mads_base import MadsCarStateBase
 from opendbc.can.parser import CANParser
+from opendbc.car.volkswagen.values import GearShifter
 
 ButtonType = structs.CarState.ButtonEvent.Type
+
+TOLERANCE_MAX     = 100 # 1 second
+TEMP_CRUISE_FAULT = 6
 
 
 class MadsCarState(MadsCarStateBase):
   def __init__(self, CP: structs.CarParams, CP_SP: structs.CarParamsSP):
     super().__init__(CP, CP_SP)
+    self.tolerance_counter = TOLERANCE_MAX
 
   def update_mads(self, ret: structs.CarState, can_parser_pt: CANParser) -> None:
     self.prev_lkas_button = self.lkas_button
 
-    # block mads from detecting a cruise state transition in parked mode while cruise is temporary not available
-    parking_brake_not_fully_open = can_parser_pt.vl["ESC_50"]["EPB_Status"] in (1, 3, 4)
-    temp_cruise_fault = can_parser_pt.vl["Motor_51"]["TSK_Status"] == 6
-    if temp_cruise_fault and parking_brake_not_fully_open:
+    # safely block MADS from detecting a cruise state transition from parked mode while cruise is temporary not available
+    # (blocking user unintended MADS enablement via main cruise state mechanism)
+    temp_cruise_fault = can_parser_pt.vl["Motor_51"]["TSK_Status"] == TEMP_CRUISE_FAULT
+    drive_mode        = ret.gearShifter == GearShifter.drive
+    
+    if temp_cruise_fault and ret.parkingBrake and not drive_mode:
       ret.cruiseState.available = True
+      self.tolerance_counter    = 0
+      
+    elif self.tolerance_counter < TOLERANCE_MAX: # grant a little bit of time for the car doing its state transition
+      ret.cruiseState.available = True
+      self.tolerance_counter    = min(self.tolerance_counter + 1, TOLERANCE_MAX)
     
     # some newer gen MEB cars do not have a main cruise button and a native cancel button is present
-    # cruise state can not be fully toggled off for these cars!    
+    # WARNING: cruise state can not be fully toggled off for these cars!    
     user_disable = False
          
     for b in ret.buttonEvents:
@@ -37,5 +47,5 @@ class MadsCarState(MadsCarStateBase):
         user_disable = True
         break
     
-    steering_enabled = can_parser_pt.vl["QFK_01"]["LatCon_HCA_Status"] == "ACTIVE" # presume mads is actively steering
+    steering_enabled = can_parser_pt.vl["QFK_01"]["LatCon_HCA_Status"] == "ACTIVE" # assume mads is actively steering
     self.lkas_button = steering_enabled and user_disable

--- a/opendbc/sunnypilot/car/volkswagen/mads.py
+++ b/opendbc/sunnypilot/car/volkswagen/mads.py
@@ -24,8 +24,6 @@ class MadsCarState(MadsCarStateBase):
     user_enable = False
     user_disable = False
     
-    cp = can_parsers[Bus.pt]
-    
     # block temp fault when parked to prevent mads self activation when car removes the temp fault by switching into a drive mode
     if can_parser_pt.vl["Motor_51"]["TSK_Status"] == 6 and ret.parkingBrake:
       ret.cruiseState.available = True

--- a/opendbc/sunnypilot/car/volkswagen/mads.py
+++ b/opendbc/sunnypilot/car/volkswagen/mads.py
@@ -22,7 +22,7 @@ class MadsCarState(MadsCarStateBase):
     super().__init__(CP, CP_SP)
     self.tolerance_counter = TOLERANCE_MAX
 
-  def update_mads(self, ret: structs.CarState, can_parser_pt: CANParser) -> None:
+  def update_mads(self, ret: structs.CarState, can_parser_pt: CANParser, hca_status) -> None:
     self.prev_lkas_button = self.lkas_button
 
     # safely block MADS from detecting a cruise state transition from parked mode while cruise is temporary not available
@@ -47,5 +47,6 @@ class MadsCarState(MadsCarStateBase):
         user_disable = True
         break
     
-    steering_enabled = can_parser_pt.vl["QFK_01"]["LatCon_HCA_Status"] == "ACTIVE" # assume mads is actively steering
+    steering_enabled = hca_status == "ACTIVE" # assume mads is actively steering
+    
     self.lkas_button = steering_enabled and user_disable

--- a/opendbc/sunnypilot/car/volkswagen/mads.py
+++ b/opendbc/sunnypilot/car/volkswagen/mads.py
@@ -55,7 +55,8 @@ class MadsCarState(MadsCarStateBase):
     
     # translate into lkas button event for MADS disable
     if self.prev_lkas_button != self.lkas_button:
+      # generate event
       ev = structs.CarState.ButtonEvent()
       ev.type = ButtonType.lkas
       ev.pressed = self.lkas_button
-      ret.buttonEvents.append(ev)
+      ret.buttonEvents = list(ret.buttonEvents) + [ev]

--- a/opendbc/sunnypilot/car/volkswagen/mads.py
+++ b/opendbc/sunnypilot/car/volkswagen/mads.py
@@ -43,7 +43,8 @@ class MadsCarState(MadsCarStateBase):
     self.prev_lkas_button = self.lkas_button
     
     # get cancel button press
-    user_disable = any(b.type == ButtonType.cancel and b.pressed for b in ret.buttonEvents)
+    user_disable = any(b.type == ButtonType.accelCruise and b.pressed for b in ret.buttonEvents) # for testing
+    #user_disable = any(b.type == ButtonType.cancel and b.pressed for b in ret.buttonEvents)
     
     # get states
     steering_enabled = hca_status == "ACTIVE" # assume mads is actively steering


### PR DESCRIPTION
A solution to block user unintended MADS activation when leaving parked state and stable canceling of MADS for MEB cars without Main Cruise Button and/or no possibility to fully shut off Cruise.
