### PR TITLE
Reliable Gas Pressed Detection Signal

### DIFF
--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -291,7 +291,8 @@ class CarState(CarStateBase, MadsCarState):
     ret.carFaultedNonCritical = cam_cp.vl["EA_01"]["EA_Funktionsstatus"] in (3, 4, 5, 6) # emergency assist always present also if not coded
 
     # Update gas, brakes, and gearshift.
-    ret.gasPressed   = pt_cp.vl["Motor_54"]["Accelerator_Pressure"] > 0 # MEB and MQBevo have offset difference of 0.4, but mqbevo can fluctuate in that range
+    #ret.gasPressed   = pt_cp.vl["Motor_54"]["Accelerator_Pressure"] > 0 # MQBevo offset is not reliable (fluctuation or different statically in small range)
+    ret.gasPressed   = pt_cp.vl["Motor_51"]["Accel_Pedal_Pressure"] > 0 # detects accel pedal "a little bit" later than ["Motor_54"]["Accelerator_Pressure"]
     ret.brakePressed = bool(pt_cp.vl["Motor_14"]["MO_Fahrer_bremst"]) # includes regen braking by user
     ret.brake        = pt_cp.vl["ESC_51"]["Brake_Pressure"]
 

--- a/opendbc/safety/modes/volkswagen_meb.h
+++ b/opendbc/safety/modes/volkswagen_meb.h
@@ -4,7 +4,6 @@
 #include "opendbc/safety/modes/volkswagen_common.h"
 
 #define MSG_ESC_51           0xFCU    // RX, for wheel speeds
-#define MSG_Motor_54         0x14CU   // RX, for accel pedal
 #define MSG_HCA_03           0x303U   // TX by OP, Heading Control Assist steering torque
 #define MSG_QFK_01           0x13DU   // RX, for steering angle
 #define MSG_ACC_19           0x300U   // RX from ECU, for ACC status
@@ -12,7 +11,7 @@
 #define MSG_GRA_ACC_01       0x12BU   // TX by OP, ACC control buttons for cancel/resume
 #define MSG_MOTOR_14         0x3BEU   // RX from ECU, for brake switch status
 #define MSG_LDW_02           0x397U   // TX by OP, Lane line recognition and text alerts
-#define MSG_Motor_51         0x10BU   // RX for TSK state
+#define MSG_Motor_51         0x10BU   // RX for TSK state and accel pedal
 #define MSG_TA_01            0x26BU   // TX for Travel Assist status
 #define MSG_EA_01            0x1A4U   // TX, for EA mitigation
 #define MSG_EA_02            0x1F0U   // TX, for EA mitigation
@@ -28,7 +27,6 @@
   {.msg = {{MSG_LH_EPS_03, 0, 8, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},  \
   {.msg = {{MSG_MOTOR_14, 0, 8, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},   \
   {.msg = {{MSG_GRA_ACC_01, 0, 8, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}}, \
-  {.msg = {{MSG_Motor_54, 0, 32, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},  \
   {.msg = {{MSG_QFK_01, 0, 32, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},    \
   
 #define VW_MEB_RX_CHECKS                                                                            \
@@ -84,8 +82,6 @@ static uint32_t volkswagen_meb_compute_crc(const CANPacket_t *msg) {
     crc ^= (uint8_t[]){0x20,0xCA,0x68,0xD5,0x1B,0x31,0xE2,0xDA,0x08,0x0A,0xD4,0xDE,0x9C,0xE4,0x35,0x5B}[counter];
   } else if (msg->addr == MSG_ESC_51) {
     crc ^= (uint8_t[]){0x77,0x5C,0xA0,0x89,0x4B,0x7C,0xBB,0xD6,0x1F,0x6C,0x4F,0xF6,0x20,0x2B,0x43,0xDD}[counter];
-  } else if (msg->addr == MSG_Motor_54) {
-    crc ^= (uint8_t[]){0x16,0x35,0x59,0x15,0x9A,0x2A,0x97,0xB8,0x0E,0x4E,0x30,0xCC,0xB3,0x07,0x01,0xAD}[counter];
   } else if (msg->addr == MSG_Motor_51) {
     crc ^= (uint8_t[]){0x77,0x5C,0xA0,0x89,0x4B,0x7C,0xBB,0xD6,0x1F,0x6C,0x4F,0xF6,0x20,0x2B,0x43,0xDD}[counter];
   } else if (msg->addr == MSG_MOTOR_14) {
@@ -292,12 +288,13 @@ static void volkswagen_meb_rx_hook(const CANPacket_t *msg) {
     if (msg->addr == MSG_MOTOR_14) {
       brake_pressed = GET_BIT(msg, 28U);
     }
-
-	// update accel pedal
-    if (msg->addr == MSG_Motor_54) {
-      int accel_pedal_value = ((msg->data[21] * 4) - 148);
+	
+    // update accel pedal
+    if (msg->addr == MSG_Motor_51) {
+      int accel_pedal_value = ((msg->data[1] >> 4) & 0x0FU) | ((msg->data[2] & 0x1FU) << 4);
       gas_pressed = accel_pedal_value > 0;
     }
+	
   }
 }
 

--- a/opendbc/safety/tests/test_volkswagen_meb.py
+++ b/opendbc/safety/tests/test_volkswagen_meb.py
@@ -15,7 +15,6 @@ MIN_ACCEL = -3.5
 # MEB message IDs
 MSG_ESC_51        = 0xFC
 MSG_QFK_01        = 0x13D
-MSG_Motor_54      = 0x14C
 MSG_Motor_51      = 0x10B
 MSG_ACC_18        = 0x14D
 MSG_MEB_ACC_01    = 0x300
@@ -58,8 +57,8 @@ class TestVolkswagenMebSafetyBase(common.CarSafetyTest, common.CurvatureSteering
 
   # Driver throttle input
   def _user_gas_msg(self, gas):
-    values = {"Accelerator_Pressure": gas}
-    return self.packer.make_can_msg_safety("Motor_54", 0, values)
+    values = {"Accel_Pedal_Pressure": gas}
+    return self.packer.make_can_msg_safety("Motor_51", 0, values)
 
   def _vehicle_moving_msg(self, speed_mps: float):
     return self._speed_msg(speed_mps)


### PR DESCRIPTION
For MQBevo the used signal Motor_54 for gas pressed detection is not reliable. It does fluctuate in small offset range or does have another static offset. Not seen to be consistent even for same cars and different drives. This results in a wrong override detection.

Use another plausible signal Motor_51 where consistent behavior is seen for MEB and MQBevo which is also already used for cruise state detection. 
