### PR TITLE
VW MQBevo: don't read ACC_19 when the radar is disabled

### DIFF
--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -355,8 +355,12 @@ class CarState(CarStateBase, MadsCarState):
       # Speed limiter mode; ECM faults if we command ACC while not pcmCruise
       ret.cruiseState.nonAdaptive = bool(pt_cp.vl["Motor_51"]["TSK_Limiter_ausgewaehlt"])
 
-    accFaulted = (pt_cp.vl["Motor_51"]["TSK_Status"] in (6, 7) or
-                  ext_cp.vl["ACC_19"]["ACC_Status_ACC"] == 6)  # reversible fault in ACC system
+    # ACC_19 is sent by the radar, which is muted when we run openpilot longitudinal on a
+    # camera harness. Any vl[] access registers the message with the CANParser timeout check,
+    # so reading it once the radar is quiet permanently invalidates the bus.
+    accFaulted = pt_cp.vl["Motor_51"]["TSK_Status"] in (6, 7)
+    if not (self.CP.flags & VolkswagenFlags.DISABLE_RADAR):
+      accFaulted = accFaulted or ext_cp.vl["ACC_19"]["ACC_Status_ACC"] == 6  # reversible fault in ACC system
     ret.accFaulted = self.update_acc_fault(accFaulted, parking_brake=ret.parkingBrake, drive_mode=drive_mode)
 
     ret_ic.radarDisableFailed = True if RADAR_DISABLE_STATE["error"] == True and self.CP.flags & VolkswagenFlags.DISABLE_RADAR else False


### PR DESCRIPTION
## Problem

On a camera harness openpilot mutes the front radar over UDS so it can take over longitudinal control (`VolkswagenFlags.DISABLE_RADAR`, which `interface.py` sets unconditionally for `NetworkLocation.fwdCamera`). `ACC_19` is one of the messages the radar stops sending.

`CANParser` registers a message for its timeout check on the **first `vl[]` access**, and learns the frequency from live traffic:

```python
# opendbc/can/parser.py
class VLDict(dict):
  def __getitem__(self, key):
    if key not in self:
      self.parser._add_message(key)     # <- also registers it for the timeout check
    return super().__getitem__(key)
```

The ACC fault check read `ACC_19` unconditionally, so the muted message stayed under a ~0.6 s timeout (learned 16.7 Hz, `timeout_threshold = 10 / frequency`). A couple of seconds after the radar went quiet `can_valid` went false and stayed false for the rest of the drive, leaving openpilot unusable for the whole trip.

The `AWV_03` and `ACC_18` reads a few lines above are already guarded the same way — `ACC_19` was just missed.

## Reproduction

2021 Golf 8 (`VOLKSWAGEN_GOLF_MK8`, MQBevo), camera harness, `flags` includes `DISABLE_RADAR`, `safetyParam = 9` (`LONG_CONTROL | DISABLE_RADAR`).

The radar disable itself works as intended:

```
Engine state is allowed: Engine_On=False
Radar disable by programming session sent on attempt 1
```

About 20 s later the radar is completely silent and openpilot has taken over at the stock rates. Measured over a driving segment:

| message | from radar | from openpilot |
| --- | --- | --- |
| `0x14D` ACC_18 | 0.0 Hz | 50.0 Hz |
| `0x300` ACC_19 | 0.0 Hz | 16.7 Hz |
| `0x24F` Strukturen_01 | 0.0 Hz | 25.0 Hz |
| `0xDB` AWV_03 | 0.0 Hz | 1.0 Hz |

From that point on every driving segment logs, roughly once per second:

```
CANParser: 0x300 ACC_19 not valid (timeout or missing)
```

`carState.canValid` is false for the entire drive and the `canError` alert is permanent.

## Before / after

Same car, same day, radar confirmed muted in both runs:

| | before | after |
| --- | --- | --- |
| `carState.canValid` true | **5 %** | **100 %** |
| `0x300 ACC_19 not valid` | ~once per second | **0** |
| `canError` events | 50 per segment | **0** |
| drive | — | 27 min, no alert |

## Also seen elsewhere

The same message was named in an earlier report from a '23 A3:

https://community.sunnypilot.ai/t/can-error-while-testing-gateway-connector-for-mqb-evo/4870

> Digging into the logs show that the 0x24c MEB_Side_Assist_01 and **0x300 ACC_19** messages are "not valid". I'm guessing that there are maybe some unexpected edge cases happening, since radar may be disabled (networkLocation is fwdCamera ...)

## Note

Once the radar is muted the stock ACC fault bit carries no information, so skipping the read loses nothing.
