### PR TITLE
VW MQBevo: request an engine restart when pulling away from a stop

### DIFF
--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -218,7 +218,10 @@ def create_acc_accel_control(packer, bus, CP, CCP, acc_type, acc_enabled, upper_
   values = {
     "ACC_Typ":                    acc_type,
     "ACC_Status_ACC":             acc_control,
-    "ACC_StartStopp_Info":        acc_enabled,
+    # 2 = engine start mandatory (start request), 1 = auto stop prohibited, 0 = auto stop allowed.
+    # acc_enabled is a bool, so this could never reach 2 and openpilot was unable to ask for a
+    # restart once the engine had auto-stopped, leaving the car unable to pull away.
+    "ACC_StartStopp_Info":        2 if (acc_enabled and starting) else (1 if acc_enabled else 0),
     "ACC_Sollbeschleunigung_02":  acceleration,
     "ACC_zul_Regelabw_unten":     lower_control_limit if acc_control in (ACC_CTRL_ACTIVE, ACC_CTRL_OVERRIDE) and not full_stop_no_start else 0,
     "ACC_zul_Regelabw_oben":      upper_control_limit if acc_control in (ACC_CTRL_ACTIVE, ACC_CTRL_OVERRIDE) and not full_stop_no_start else 0,


### PR DESCRIPTION
## Problem

`ACC_StartStopp_Info` in `ACC_18` is a 2 bit signal:

```
0  Motorlauf_langfristig_nicht_notwendig_Stoppfreigabe          auto stop allowed
1  Motoranlauf_nicht_zwingend_notwendig_Stoppverbot_
   keine_Startanforderung                                       auto stop prohibited, no start request
2  Motoranlauf_zwingend_notwendig_Startanforderung              start request
3  Systemfehler
```

It was fed `acc_enabled`, a bool, so it could only ever be 0 or 1 — **the start request was unreachable**.

While openpilot is engaged it sends 1, which prohibits the auto stop, so the engine never stops and this goes unnoticed. The gap shows up when the engine is already stopped:

1. Driver brakes to a stop themselves, openpilot longitudinal disengages
2. `acc_enabled` is false, so `ACC_StartStopp_Info` = 0 — the car is told it may auto stop, and it does
3. Driver presses SET to re-engage; the best the signal can now reach is 1, and prohibiting a stop is not requesting a start
4. The car sits there. The only way out is the throttle, which also cancels longitudinal, so the driver has to SET again once moving

## What the stock radar does

Captured from the same car with openpilot longitudinal off, stock ACC holding at a standstill:

```
(ACC_StartStopp_Info, ACC_Anfahren, ACC_Anforderung_HMS)
  (Stoppverbot,    1, anfahren)             x51
  (Stoppfreigabe,  1, halten)               x32
  (Stoppverbot,    1, Loesen_ueber_Rampe)   x1
```

The stock system moves this signal around with the hold state rather than pinning it to "ACC is on".

## Fix

Send 2 while the start request is latched, keeping the existing 1/0 behaviour otherwise.

## Testing

2021 Golf 8 (`VOLKSWAGEN_GOLF_MK8`, MQBevo), camera harness, openpilot longitudinal enabled.

Reproduced before the change: brake to a stop, wait for the engine to auto stop, press SET — the car stays put until the throttle is used.

After the change, the same sequence restarts the engine and pulls away under openpilot. Confirmed on the road.

## Note

This does not change behaviour while openpilot is holding the car itself: `starting` is only latched during the pull-away, so the signal still reads 1 for the rest of the stop and the engine is still kept running.
